### PR TITLE
Add pytest framework trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ if __name__ == '__main__':
                 'Topic :: Software Development :: Testing',
                 'License :: OSI Approved :: Apache Software License',
                 'Development Status :: 4 - Beta',
+                'Framework :: Pytest',
                 'Programming Language :: Python :: 2',
                 'Programming Language :: Python :: 2.6',
                 'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Adding the trove classifier will signal that datatest also acts as a pytest plugin. This will also help https://plugincompat.herokuapp.com to find it and list it as a plugin and do regular installation checks.

For further details see this recently merged PR from hypothesis: https://github.com/HypothesisWorks/hypothesis/pull/1306