### PR TITLE
Fix syntax of `python_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ if __name__ == '__main__':
             project_urls={
                 'Documentation': 'https://datatest.readthedocs.io/',
             },
-            python_requires='>=2.6.*, !=3.0.*, !=3.1.*',
+            python_requires='>=2.6, !=3.0.*, !=3.1.*',
             description='Test driven data-wrangling and data validation.',
             long_description=long_description,
             long_description_content_type='text/x-rst',


### PR DESCRIPTION
`>=2.6.*` isn't valid syntax for `python_requires`(see [PEP 440](https://www.python.org/dev/peps/pep-0440/)).

This was causing an alpha release of Poetry to fail to install this package. I think they're going to fix it in future releases, but regardless it'd be helpful if this syntax was fixed.